### PR TITLE
Enabled default template to be replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,20 @@ Then use as a custom element anywhere throughout your application:
 ```html
   <aurelia-flatpickr config.bind="config" value.bind="value"></aurelia-flatpickr>
   ```
+### Using Custom Input Groups
+The default template for the input element can be replaced to customise the buttons available. Here's an example:
 
+```html
+<aurelia-flatpickr config.bind="{wrap:true}">
+  <div class="input-group aurelia-flatpickr">
+      <input type="text" class="form-control" placeholder="Select date" data-input>
+      <span class="input-group-btn">
+          <button class="btn btn-default" type="button" data-clear>Clear</button>
+          <button class="btn btn-default" type="button" data-toggle>Show</button>
+      </span>
+  </div>
+</aurelia-flatpickr>
+   ```
 ## Running The Tests
 
 To run the unit tests, first ensure that you have followed the steps above in order to install all dependencies and successfully build the library. Once you have done that, proceed with these additional steps:

--- a/dist/amd/aurelia-flatpickr.html
+++ b/dist/amd/aurelia-flatpickr.html
@@ -1,4 +1,6 @@
 <template>
     <require from="flatpickr/dist/flatpickr.css"></require>
-    <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
+        <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
 </template>

--- a/dist/commonjs/aurelia-flatpickr.html
+++ b/dist/commonjs/aurelia-flatpickr.html
@@ -1,4 +1,6 @@
 <template>
     <require from="flatpickr/dist/flatpickr.css"></require>
-    <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
+        <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
 </template>

--- a/dist/es2015/aurelia-flatpickr.html
+++ b/dist/es2015/aurelia-flatpickr.html
@@ -1,4 +1,6 @@
 <template>
     <require from="flatpickr/dist/flatpickr.css"></require>
-    <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
+        <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
 </template>

--- a/dist/system/aurelia-flatpickr.html
+++ b/dist/system/aurelia-flatpickr.html
@@ -1,4 +1,6 @@
 <template>
     <require from="flatpickr/dist/flatpickr.css"></require>
-    <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
+        <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
 </template>

--- a/src/aurelia-flatpickr.html
+++ b/src/aurelia-flatpickr.html
@@ -1,4 +1,6 @@
 <template>
     <require from="flatpickr/dist/flatpickr.css"></require>
-    <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
+        <input  class="aurelia-flatpickr" type="text" placeholder="Select Date..">
+    <slot>
 </template>


### PR DESCRIPTION
This pull request enables the default template of the custom element to be replaced, making it possible to use the wrap feature (see "Custom Elements and Input Groups" here).

(This request replaces the one I sent ten days ago: #1: it has just the change to the template, and an addition to the ReadMe)